### PR TITLE
If relname contains spaces and is not quoted write_arff will add quotes

### DIFF
--- a/arff_write.m
+++ b/arff_write.m
@@ -69,6 +69,13 @@ function [] = arff_write(arff_file, data, relname, nomspec)
         error('%s is not a valid arff_file', arff_file);
     end
     
+    % if relname contains spaces check that is quoted
+    % if not add them
+    quoted = strcmp('""', [relname(1) relname(end)]);
+    if nnz(isspace(relname)) && ~quoted
+        relname = ['"' relname '"'];
+    end
+
     % write relname
     fprintf(fid, '@RELATION %s\n\n', relname);
     


### PR DESCRIPTION
I add a simple check to relname.
If relname contains spaces should be quoted.
If it's not quoted then it will add a double quote at begging and end.
